### PR TITLE
extentionを追加、コードのカプセル化

### DIFF
--- a/Sample_TwitterTopScreen/Models/Tweet.swift
+++ b/Sample_TwitterTopScreen/Models/Tweet.swift
@@ -40,4 +40,3 @@ func updateTweets(comment: String, pickedImage: UIImage?) -> [Tweet] {
         return tweets
     }
 
-

--- a/Sample_TwitterTopScreen/ViewControllers/NextVC.swift
+++ b/Sample_TwitterTopScreen/ViewControllers/NextVC.swift
@@ -7,43 +7,43 @@
 
 import UIKit
 
-class NextVC: UIViewController, UITableViewDataSource {
+class NextVC: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
+    
     var tweet:Tweet!
     var tableviewCell = TableViewCell()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupTableView()
+    }
+    
+    //Tableviewの設定
+    private func setupTableView() {
         tableView.dataSource = self
+        tableView.register(UINib(nibName: "TableViewCell", bundle: nil), forCellReuseIdentifier: "cell")
+        
         //make one tableviewCell
         tableView.rowHeight = CGFloat(view.frame.height)
         
         //make a tableviewCell not selectable
-        self.tableView.allowsSelection = false
-
-        tableView.register(UINib(nibName: "TableViewCell", bundle: nil), forCellReuseIdentifier: "cell")        
+        tableView.allowsSelection = false
     }
+}
+
+
+extension NextVC: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         1
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! TableViewCell
-        cell.profileImageView.image = tweet.icon
-        cell.nameLabel.text = tweet.name
-        cell.timeLabel.text = tweet.time
-        cell.textContentLabel.text = tweet.text
+        cell.setupCell(tweet: tweet)
         cell.textContentLabel.font = UIFont.systemFont(ofSize: 23.0)
-        //デフォルトは写真の表示をオフにしておく
-        cell.imageContent.isHidden = true
-        //写真が選択された際は写真を表示する
-        if let image = tweet.tweetImage {
-            cell.imageContent.isHidden = false
-            cell.imageContent.image = image
-
-        }
+        
         return cell
     }
 

--- a/Sample_TwitterTopScreen/ViewControllers/TweetListVC.swift
+++ b/Sample_TwitterTopScreen/ViewControllers/TweetListVC.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class TweetListVC: UIViewController, ModalViewControllerDelegate {
+class TweetListVC: UIViewController {
     
     let modalView = ModalViewController(nibName:"ModalViewController", bundle: nil)
 
@@ -18,18 +18,25 @@ class TweetListVC: UIViewController, ModalViewControllerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.delegate = self
-        tableView.dataSource = self
-        modalView.delegate = self
-        
-        tableView.register(UINib(nibName: "TableViewCell", bundle: nil), forCellReuseIdentifier: "cell")
-        modalView.modalPresentationStyle = .fullScreen
-        
-        tableView.estimatedRowHeight = 200
-        
+        setupTableView()
+        setupModalView()
         addNavBarImage()
         buttonLayout()
     }
+    
+    //TableViewの設定
+    private func setupTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UINib(nibName: "TableViewCell", bundle: nil), forCellReuseIdentifier: "cell")
+    }
+    
+    //ModalViewの設定
+    func setupModalView() {
+        modalView.delegate = self
+        modalView.modalPresentationStyle = .fullScreen
+    }
+
     
     //NavigationBarにアイコンを配置
     func addNavBarImage() {
@@ -71,26 +78,33 @@ class TweetListVC: UIViewController, ModalViewControllerDelegate {
         addButton.layer.insertSublayer(shadowLayer, at: 0)
     }
 
+    //Action on pressing the FloatingButton
+    @IBAction func addCommentButton(_ sender: Any) {
+        // 作成したViewControllerをモーダル表示する
+        self.present(modalView, animated: true)
+    }
+}
+
+//ModalViewControllerDelegateのProtocolに準拠させる
+extension TweetListVC: ModalViewControllerDelegate {
+    
     //When coming back from the modal view
     func modalDidFinish(comment: String, imageView: UIImage?) {
         tweets = updateTweets(comment: comment, pickedImage: imageView)
         tableView.reloadData()
         modalView.dismiss(animated: true, completion: nil)
     }
-
-    //Action on pressing the FloatingButton
-    @IBAction func addCommentButton(_ sender: Any) {
-        // 作成したViewControllerをモーダル表示する
-        self.present(modalView, animated: true)
-    }
-    
-
 }
+
 
 extension TweetListVC: UITableViewDelegate, UITableViewDataSource {
     //Cellの高さ
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        200
     }
     
     //Cellを選択したら遷移
@@ -103,22 +117,10 @@ extension TweetListVC: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return tweets.count
         }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! TableViewCell
-        let tweet = self.tweets[indexPath.row]
-        cell.profileImageView.image = tweet.icon
-        cell.nameLabel.text = tweet.name
-        cell.timeLabel.text = tweet.time
-        cell.textContentLabel.text = tweet.text
-        //デフォルトは写真の表示をオフにしておく
-        cell.imageContent.isHidden = true
-        //写真が選択された際は写真を表示する
-        if let image = tweet.tweetImage {
-            cell.imageContent.isHidden = false
-            cell.imageContent.image = image
-            cell.imageContent.contentMode = .scaleAspectFill
-        }
+        cell.setupCell(tweet: tweets[indexPath.row])
         return cell
     }
     

--- a/Sample_TwitterTopScreen/Views/ModalViewController.swift
+++ b/Sample_TwitterTopScreen/Views/ModalViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 protocol ModalViewControllerDelegate {
     func modalDidFinish(comment: String, imageView: UIImage?)
-
 }
 
 class ModalViewController: UIViewController, UINavigationControllerDelegate, UITextViewDelegate {
@@ -21,17 +20,13 @@ class ModalViewController: UIViewController, UINavigationControllerDelegate, UIT
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         textView.delegate = self
         
         //キーボード上部にDoneボタンを追加
         makeToolBar()
-        
         //キーボード外を押したらキーボードを閉じる
-        let recognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeybord))
-        self.view.addGestureRecognizer(recognizer)
-        
-        //選択した画像の角を丸くする
-        imageView.layer.cornerRadius = imageView.bounds.size.height / 4
+        dismissKeyboardTouchingOutside()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -52,7 +47,7 @@ class ModalViewController: UIViewController, UINavigationControllerDelegate, UIT
         //閉じるボタンを右に配置するためのスペース
         let spacer = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: self, action: nil)
         //閉じるボタン
-        let doneButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.done, target: self, action: #selector(dismissKeybord))
+        let doneButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.done, target: self, action: #selector(dismissKeyboard))
         //スペース・閉じるボタンを配置
         toolBar.items = [spacer, doneButton]
         //textViewのキーボードにToolbarを配置
@@ -60,8 +55,14 @@ class ModalViewController: UIViewController, UINavigationControllerDelegate, UIT
     }
 
     //キーボードを閉じるアクション
-    @objc func dismissKeybord() {
+    @objc func dismissKeyboard() {
         self.view.endEditing(true)
+    }
+    
+    //キーボード外を押したらキーボードを閉じる
+    func dismissKeyboardTouchingOutside() {
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(recognizer)
     }
     
     
@@ -97,9 +98,11 @@ extension ModalViewController: UIImagePickerControllerDelegate {
             //imageViewにカメラロールから選んだ画像を表示する
             imageView.image = selectedImage
             imageView.contentMode = .scaleAspectFill
+            //選択した画像の角を丸くする
+            imageView.layer.cornerRadius = imageView.bounds.size.height / 4
         }
         //画像をImageViewに表示したらアルバムを閉じる
         self.dismiss(animated: true)
-        dismissKeybord()
+        dismissKeyboard()
     }
 }

--- a/Sample_TwitterTopScreen/Views/TableViewCell.swift
+++ b/Sample_TwitterTopScreen/Views/TableViewCell.swift
@@ -15,5 +15,19 @@ class TableViewCell: UITableViewCell {
     @IBOutlet weak var textContentLabel: UILabel!
     @IBOutlet weak var imageContent: UIImageView!
 
-
+    //ラベル・Imageviewにデータをセットする
+    func setupCell(tweet: Tweet) {
+        profileImageView.image = tweet.icon
+        nameLabel.text = tweet.name
+        timeLabel.text = tweet.time
+        textContentLabel.text = tweet.text
+        //デフォルトは写真の表示をオフにしておく
+        imageContent.isHidden = true
+        //写真が選択された際は写真を表示する
+        if let image = tweet.tweetImage {
+            imageContent.isHidden = false
+            imageContent.image = image
+            imageContent.contentMode = .scaleAspectFill
+        }
+    }
 }


### PR DESCRIPTION
## 目的
+ Extentionを使用し、Protocol準拠部分を分かりやすくする
+ コードを「意味のある最小単位」にカプセル化
## 関連するIssue等
+ #1 _コードはできるだけカプセル化する_
+ #2 _Protocolに準拠する場合はできるだけExtensionを利用する_
## レビューポイント
+ Tableviewの設定( [TweetListVC](https://github.com/lualualua/Twitter_like_tableview-/blob/1b7d85aa31f0e6435eec357bea90dbcc8c24cb4a/Sample_TwitterTopScreen/ViewControllers/TweetListVC.swift#L27-L32) )( [NextVC](https://github.com/lualualua/Twitter_like_tableview-/blob/1b7d85aa31f0e6435eec357bea90dbcc8c24cb4a/Sample_TwitterTopScreen/ViewControllers/NextVC.swift#L22-L32) )、ModalViewの[設定](https://github.com/lualualua/Twitter_like_tableview-/blob/1b7d85aa31f0e6435eec357bea90dbcc8c24cb4a/Sample_TwitterTopScreen/ViewControllers/TweetListVC.swift#L34-L38)、TableviewCellのラベル・画像の[設定]()をカプセル化しました。
（tableViewの設定は、TweetListVC・NextVCともにほぼ同じコードだったので、それぞれのViewController内でカプセル化するのではなく、まとめて1つのFunctionとした方がいいかと考えましたが、TweetListVCとNextVCは全く同じTableViewのレイアウトではなく少し異なる部分もあるため、それぞれのファイルでFunction化したが、まとめた方が良いのでしょうか？）

+ Extentionを[作成](https://github.com/lualualua/Twitter_like_tableview-/blob/1b7d85aa31f0e6435eec357bea90dbcc8c24cb4a/Sample_TwitterTopScreen/ViewControllers/TweetListVC.swift#L89-L96)しました。
